### PR TITLE
feat: delete Talos Linux group

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -19,14 +19,5 @@
         commitMessageTopic: "{{{groupName}}} group",
       },
     },
-    {
-      description: "Talos Linux",
-      groupName: "Talos-Linux",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/siderolabs/kubelet/", "/siderolabs/installer/"],
-      group: {
-        commitMessageTopic: "{{{groupName}}} group",
-      },
-    }
   ],
 }


### PR DESCRIPTION
Removed Talos Linux group configuration from Renovate.