### PR TITLE
fix(renovate): talos and kubernetes matching

### DIFF
--- a/.renovate/changelogs.json5
+++ b/.renovate/changelogs.json5
@@ -1,0 +1,15 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Changelog URL for 1Password Connect",
+      matchPackageNames: ["/1password/"],
+      changelogUrl: "https://github.com/1Password/connect/blob/main/CHANGELOG.md",
+    },
+    {
+      description: "Changelog URL for Cloudflared",
+      matchPackageNames: ["/cloudflared/"],
+      changelogUrl: "https://github.com/cloudflare/cloudflared/blob/master/RELEASE_NOTES",
+    },
+  ],
+}

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -7,7 +7,7 @@
       fileMatch: [
         "(^|/).+\\.env$",
         "(^|/).+\\.sh$",
-        "(^|/).+\\.ya?ml(?:\\.j2)?$",
+        "(^|/).+\\.ya?ml$",
       ],
       matchStrings: [
         // # renovate: datasource=github-releases depName=k3s-io/k3s
@@ -15,7 +15,7 @@
         // # renovate: datasource=helm depName=cilium repository=https://helm.cilium.io
         // version: 1.15.1
         // # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-        // KUBERNETES_VERSION=v1.31.1
+        // version: v1.31.1
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
         // # renovate: datasource=docker depName=ghcr.io/prometheus-operator/prometheus-operator
         // https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -3,7 +3,7 @@
   packageRules: [
     {
       description: "Actions Runner Controller Group",
-      groupName: "Actions Runner Controller",
+      groupName: "actions-runner-controller",
       matchDatasources: ["docker"],
       matchPackageNames: ["/gha-runner-scale-set-controller/", "/gha-runner-scale-set/"],
       group: {
@@ -12,21 +12,39 @@
     },
     {
       description: "Intel Device Plugins Group",
-      groupName: "Intel-Device-Plugins",
+      groupName: "intel-device-plugins",
       matchDatasources: ["docker"],
       matchPackageNames: ["/intel-device-plugins-operator/", "/intel-device-plugins-gpu/"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
+      minimumGroupSize: 2,
     },
     {
-      description: "Talos Linux Group",
-      groupName: "Talos-Linux",
+      description: "Kubernetes Group",
+      groupName: "kubernetes",
       matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/siderolabs/kubelet", "ghcr.io/siderolabs/installer"],
+      matchPackageNames: [
+        "/kube-apiserver/",
+        "/kube-controller-manager/",
+        "/kube-proxy/",
+        "/kube-scheduler/",
+        "/kubelet/",
+      ],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
+      minimumGroupSize: 5,
+    },
+    {
+      description: "Talos Group",
+      groupName: "talos",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/installer/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 2,
     },
   ],
 }

--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -1,0 +1,11 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Override Talos Installer Package Name",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/factory\\.talos\\.dev/"],
+      overridePackageName: "ghcr.io/siderolabs/installer",
+    },
+  ],
+}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -10,6 +10,7 @@
     'github>smauermann/homelab//.renovate/groups.json5',
     'github>smauermann/homelab//.renovate/labels.json5',
     'github>smauermann/homelab//.renovate/semanticCommits.json5',
+    'github>smauermann/homelab//.renovate/overrides.json5',
     ':disableRateLimiting',
     ':dependencyDashboard',
     ':rebaseStalePrs',
@@ -27,7 +28,7 @@
   ],
   kubernetes: {
     managerFilePatterns: [
-      "/^kubernetes/.+\\.ya?ml$/"
+      "/\\.ya?ml$/"
     ],
   },
   packageRules: [

--- a/talos/base.yaml
+++ b/talos/base.yaml
@@ -38,8 +38,7 @@ machine:
         rsize=1048576
         wsize=1048576
   install:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    image: factory.talos.dev/installer/$SCHEMATIC:v1.11.5
+    image: factory.talos.dev/installer/0bce9319e507615243ddd3462dd2942e035ba8e7a3fb896c8072cc863dcc79b9:v1.11.5
   kubelet:
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
@@ -49,7 +48,6 @@ machine:
       maxParallelImagePulls: 3
       # allow parallel image downloadeds
       serializeImagePulls: false
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     image: ghcr.io/siderolabs/kubelet:v1.34.2
     nodeIP:
       validSubnets:
@@ -123,7 +121,6 @@ cluster:
       enable-aggregator-routing: "true"
       feature-gates: MutatingAdmissionPolicy=true,ResourceHealthStatus=true
       runtime-config: admissionregistration.k8s.io/v1beta1=true
-    # renovate: datasource=docker depName=registry.k8s.io/kube-apiserver
     image: registry.k8s.io/kube-apiserver:v1.34.2
   ca:
     crt: op://Homelab/talos/CLUSTER_CA_CRT
@@ -132,7 +129,6 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
-    # renovate: datasource=docker depName=registry.k8s.io/kube-controller-manager
     image: registry.k8s.io/kube-controller-manager:v1.34.2
   controlPlane:
     endpoint: https://cp.talos.internal:6443
@@ -162,7 +158,6 @@ cluster:
     cni:
       name: none
   proxy:
-    # renovate: datasource=docker depName=registry.k8s.io/kube-proxy
     image: registry.k8s.io/kube-proxy:v1.34.2
     disabled: true
   scheduler:
@@ -185,7 +180,6 @@ cluster:
                     whenUnsatisfiable: ScheduleAnyway
     extraArgs:
       bind-address: 0.0.0.0
-    # renovate: datasource=docker depName=registry.k8s.io/kube-scheduler
     image: registry.k8s.io/kube-scheduler:v1.34.2
   secret: op://Homelab/talos/CLUSTER_SECRET
   secretboxEncryptionSecret: op://Homelab/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET


### PR DESCRIPTION
- Extend kubernetes manager to match all yaml files so it can detect docker images in talos machine config files natively
- Remove # renovate: comments from talos/base.yaml that caused the custom regex manager to extract incorrect version values
- Add overrides.json5 to extends to map factory.talos.dev images to ghcr.io/siderolabs/installer for version lookups
- Create Kubernetes group for kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler, and kubelet images
- Rename Talos group to only include the installer image