### PR TITLE
fix(tailscale): disable TPM state encryption for HA subnet routers

### DIFF
--- a/kubernetes/infrastructure/network/tailscale-operator/subnet-router.yaml
+++ b/kubernetes/infrastructure/network/tailscale-operator/subnet-router.yaml
@@ -11,6 +11,10 @@ spec:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
+      tailscaleContainer:
+        env:
+          - name: TS_ENCRYPT_STATE
+            value: "false"
 ---
 apiVersion: tailscale.com/v1alpha1
 kind: Connector


### PR DESCRIPTION
## Summary

- Disable TPM-based state encryption for Tailscale subnet router pods using the high-availability ProxyClass
- Fixes pod startup failures when pods reschedule to different nodes (TPM keys are node-specific)

## Problem

Tailscale 1.90.2+ encrypts state using TPM by default. When HA subnet router pods move between nodes, they fail with:
```
tpm2.Load: TPM_RC_INTEGRITY (parameter 1): integrity check failed
```

## Solution

Set `TS_ENCRYPT_STATE=false` on the tailscale container to disable TPM encryption, making state portable across nodes.

## Test plan

- [ ] Deploy the ProxyClass change
- [ ] Delete existing state secrets: `kubectl delete secret -n tailscale -l tailscale.com/parent-resource=loadbalancer-cidrs`
- [ ] Verify pods start successfully and subnet routes are advertised