### PR TITLE
feat(unbound): switch to custom Wolfi-based unbound image

### DIFF
--- a/kubernetes/infrastructure/network/dns/unbound/config/unbound.conf
+++ b/kubernetes/infrastructure/network/dns/unbound/config/unbound.conf
@@ -1,12 +1,13 @@
 server:
-    # See https://github.com/MatthewVance/unbound-docker/blob/master/unbound.conf for details
     interface: 0.0.0.0
     port: 53
 
     cache-max-ttl: 86400
     cache-min-ttl: 300
 
-    directory: "/opt/unbound/etc/unbound"
+    directory: "/etc/unbound"
+    chroot: ""
+    pidfile: ""
 
     do-ip4: yes
     do-ip6: no
@@ -16,7 +17,9 @@ server:
 
     edns-buffer-size: 1232
     rrset-roundrobin: yes
-    username: "_unbound"
+
+    # don't drop privileges - running as non-root in k8s
+    username: ""
 
     # log to stdout
     logfile: ""
@@ -89,9 +92,7 @@ server:
     private-domain: deepl.dev
     private-domain: amazonaws.com
 
-    auto-trust-anchor-file: "var/root.key"
-
-    chroot: "/opt/unbound/etc/unbound"
+    trust-anchor-file: /usr/share/dnssec-root/trusted-key.key
 
     deny-any: yes
 

--- a/kubernetes/infrastructure/network/dns/unbound/deployment.yaml
+++ b/kubernetes/infrastructure/network/dns/unbound/deployment.yaml
@@ -22,12 +22,16 @@ spec:
               app.kubernetes.io/name: unbound
           matchLabelKeys:
             - pod-template-hash
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: unbound
-          image: docker.io/mvance/unbound:1.22.0@sha256:76906da36d1806f3387338f15dcf8b357c51ce6897fb6450d6ce010460927e90
+          image: ghcr.io/smauermann/unbound:1.24.2
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
           ports:
             - name: dns-tcp
               containerPort: 53
@@ -44,13 +48,13 @@ spec:
               memory: 256Mi
           startupProbe:
             exec:
-              command: ["drill", "@127.0.0.1", "-p", "53", "google.com"]
+              command: ["dig", "+short", "@127.0.0.1", "-p", "53", "google.com"]
             failureThreshold: 3
             timeoutSeconds: 5
             initialDelaySeconds: 10
           volumeMounts:
             - name: config
-              mountPath: /opt/unbound/etc/unbound/unbound.conf
+              mountPath: /etc/unbound/unbound.conf
               subPath: unbound.conf
       volumes:
         - name: config


### PR DESCRIPTION
## Summary
- Switch from `docker.io/mvance/unbound:1.22.0` to custom `ghcr.io/smauermann/unbound:1.24.2`
- New image is Wolfi-based with unbound 1.24.2 (latest)
- Run as non-root user 1000 with read-only root filesystem

## Changes
- **Image**: Wolfi-based, glibc, latest unbound 1.24.2
- **Security**: runAsUser 1000, readOnlyRootFilesystem: true
- **Config**: Updated paths for new image (`/etc/unbound` instead of `/opt/unbound/etc/unbound`)
- **Health check**: Changed from `drill` to `dig`
- **Rootless**: Disabled chroot and pidfile

## Test plan
- [ ] Merge unbound image PR in smauermann/images first
- [ ] Verify image is published to ghcr.io
- [ ] Deploy to cluster and verify DNS resolution
- [ ] Check logs for errors