### PR TITLE
feat(external-dns): add gateway-grpcroute source

### DIFF
--- a/kubernetes/infrastructure/network/external-dns/values.yaml
+++ b/kubernetes/infrastructure/network/external-dns/values.yaml
@@ -16,3 +16,4 @@ domainFilters:
 sources:
   - ingress
   - gateway-httproute
+  - gateway-grpcroute


### PR DESCRIPTION
Enable external-dns to watch GRPCRoute resources so that otel-grpc.costanza.cloud gets a DNS entry.