### PR TITLE
fix(grafana): correct Tempo datasource port from 3100 to 3200

### DIFF
--- a/kubernetes/infrastructure/monitoring/grafana/values.yaml
+++ b/kubernetes/infrastructure/monitoring/grafana/values.yaml
@@ -92,7 +92,7 @@ datasources:
       - name: Tempo
         type: tempo
         access: proxy
-        url: http://tempo.tempo.svc.cluster.local:3100
+        url: http://tempo.tempo.svc.cluster.local:3200
         jsonData:
           httpMethod: GET
           tracesToLogsV2:


### PR DESCRIPTION
Tempo's HTTP API listens on port 3200, not 3100.