### PR TITLE
fix(argocd): pin kustomize to 5.7.1

### DIFF
--- a/kubernetes/infrastructure/workloads/argocd/values.yaml
+++ b/kubernetes/infrastructure/workloads/argocd/values.yaml
@@ -79,6 +79,26 @@ configs:
         clusters:
           - "*"
 
+# Pin kustomize to 5.7.1 to work around namespace bug in 5.8.0
+# https://github.com/kubernetes-sigs/kustomize/issues/6014
+repoServer:
+  volumes:
+    - name: custom-tools
+      emptyDir: {}
+  initContainers:
+    - name: download-kustomize
+      image: alpine:3.21
+      command: [sh, -c]
+      args:
+        - wget -qO- https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.7.1/kustomize_v5.7.1_linux_amd64.tar.gz | tar -xzf - -C /custom-tools/
+      volumeMounts:
+        - mountPath: /custom-tools
+          name: custom-tools
+  volumeMounts:
+    - mountPath: /usr/local/bin/kustomize
+      name: custom-tools
+      subPath: kustomize
+
 server:
   ingress:
     enabled: false


### PR DESCRIPTION
## Summary

Work around namespace bug in kustomize 5.8.0 bundled with ArgoCD 3.3.0.

The bug causes helm chart resources to lose their namespace metadata, resulting in VolSync resources being created in the `argocd` namespace instead of their intended namespaces.

**Root cause:** https://github.com/kubernetes-sigs/kustomize/issues/6014

## Fix

Pin kustomize to 5.7.1 using an init container in the repo-server that downloads and mounts the working version.

## Test plan

- [ ] ArgoCD repo-server pod starts successfully
- [ ] VolSync apps no longer show as OutOfSync
- [ ] ReplicationSource/ReplicationDestination created in correct namespaces