### PR TITLE
fix(pvc-backup): add explicit namespace to helmCharts entries

### DIFF
--- a/kubernetes/applications/mealie/kustomization.yaml
+++ b/kubernetes/applications/mealie/kustomization.yaml
@@ -16,6 +16,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: mealie-backup
+    namespace: *app
     valuesInline:
       appName: *app
       backup:

--- a/kubernetes/applications/media/arr/bazarr/kustomization.yaml
+++ b/kubernetes/applications/media/arr/bazarr/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: bazarr-backup
+    namespace: arr
     valuesInline:
       appName: bazarr
       backup:

--- a/kubernetes/applications/media/arr/jellyseerr/kustomization.yaml
+++ b/kubernetes/applications/media/arr/jellyseerr/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: jellyseerr-backup
+    namespace: arr
     valuesInline:
       appName: jellyseerr
       backup:

--- a/kubernetes/applications/media/arr/prowlarr/kustomization.yaml
+++ b/kubernetes/applications/media/arr/prowlarr/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: prowlarr-backup
+    namespace: arr
     valuesInline:
       appName: prowlarr
       backup:

--- a/kubernetes/applications/media/arr/radarr/kustomization.yaml
+++ b/kubernetes/applications/media/arr/radarr/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: radarr-backup
+    namespace: arr
     valuesInline:
       appName: radarr
       backup:

--- a/kubernetes/applications/media/arr/sonarr/kustomization.yaml
+++ b/kubernetes/applications/media/arr/sonarr/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: sonarr-backup
+    namespace: arr
     valuesInline:
       appName: sonarr
       backup:

--- a/kubernetes/applications/media/calibre-web/kustomization.yaml
+++ b/kubernetes/applications/media/calibre-web/kustomization.yaml
@@ -16,6 +16,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: calibre-web-backup
+    namespace: *app
     valuesInline:
       appName: *app
       backup:

--- a/kubernetes/applications/media/jellyfin/kustomization.yaml
+++ b/kubernetes/applications/media/jellyfin/kustomization.yaml
@@ -17,6 +17,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: jellyfin-backup
+    namespace: *app
     valuesInline:
       appName: *app
       backup:

--- a/kubernetes/applications/media/sabnzbd/kustomization.yaml
+++ b/kubernetes/applications/media/sabnzbd/kustomization.yaml
@@ -16,6 +16,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: sabnzbd-backup
+    namespace: *app
     valuesInline:
       appName: *app
       backup:

--- a/kubernetes/infrastructure/auth/pocket-id/kustomization.yaml
+++ b/kubernetes/infrastructure/auth/pocket-id/kustomization.yaml
@@ -17,6 +17,7 @@ helmCharts:
     repo: https://smauermann.github.io/helm-charts
     version: 2.2.1
     releaseName: pocket-id-backup
+    namespace: *app
     valuesInline:
       appName: *app
       backup:


### PR DESCRIPTION
## Summary

Add explicit `namespace:` field to all pvc-backup helmCharts entries to match the app-template pattern.

This is required because kustomize 5.8.0 has a bug where it ignores the helmCharts namespace field. Even with the kustomize 5.7.1 pin from #1199, having explicit namespace is the correct configuration.

## Test plan

- [ ] VolSync resources created in correct namespaces
- [ ] ArgoCD shows apps as Synced