### PR TITLE
fix(otel): convert delta to cumulative temporality for metrics

### DIFF
--- a/kubernetes/infrastructure/monitoring/otel-collector/values.yaml
+++ b/kubernetes/infrastructure/monitoring/otel-collector/values.yaml
@@ -65,6 +65,8 @@ config:
     batch:
       timeout: 10s
       send_batch_size: 1024
+    deltatocumulative:
+      max_stale: 5m
     memory_limiter:
       check_interval: 1s
       limit_mib: 400
@@ -104,7 +106,7 @@ config:
         exporters: [otlp/tempo, debug]
       metrics:
         receivers: [otlp]
-        processors: [memory_limiter, batch]
+        processors: [memory_limiter, deltatocumulative, batch]
         exporters: [otlphttp/victoriametrics, debug]
       logs:
         receivers: [otlp]


### PR DESCRIPTION
## Summary
- Add `deltatocumulative` processor to the OTEL collector metrics pipeline
- Claude Code emits metrics with delta aggregation temporality, which VictoriaMetrics does not support, causing VMAgent to silently drop all Claude Code metrics
- VMAgent logs showed: `unsupported delta temporality for "claude_code_cost_usage_USD_total" ('sum'): skipping it`

## Test plan
- [ ] Verify OTEL collector starts without errors after sync
- [ ] Check VMAgent logs no longer show `unsupported delta temporality` warnings
- [ ] Confirm Claude Code metrics (e.g. `claude_code_cost_usage_USD_total`) appear in VictoriaMetrics